### PR TITLE
Made

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,9 @@ docs/_build/
 # PyBuilder
 target/
 
+# Pycharm
+,idea/
+
 # Jupyter Notebook
 .ipynb_checkpoints
 

--- a/.gitignore
+++ b/.gitignore
@@ -75,7 +75,7 @@ docs/_build/
 target/
 
 # Pycharm
-,idea/
+.idea/
 
 # Jupyter Notebook
 .ipynb_checkpoints

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,4 +6,6 @@
 
 ## Contributors
 
-None yet. Why not be the first?
+- [Emmanouil Krasanakis](https://github.com/maniospas)
+
+Why not be the second?

--- a/ouro/__main__.py
+++ b/ouro/__main__.py
@@ -40,6 +40,15 @@ def parse():
         help="increase output verbosity (print report to console)",
     )
     parser.add_argument(
+        "-t",
+        "--strict",
+        action="store_true",
+        help=(
+            "analyse internal function imports "
+            + "(normally skipped because they cause no errors)"
+        ),
+    )
+    parser.add_argument(
         "--no-categorize",
         action="store_true",
         help="don't categorize cycles (mark all cycles as critical)",
@@ -72,11 +81,15 @@ def main():
     logger.info(f" ==> PATH       : {args.path}")
     logger.info(f" ==> EXPORT     : {args.export}")
     logger.info(f" ==> VERBOSE    : {args.verbose}")
+    logger.info(f" ==> STRICT     : {args.strict}")
     logger.info(f" ==> IGNORING   : {args.ignore}")
     logger.info(f" ==> CATEGORIZE : {not args.no_categorize}")
 
     checker = Checker(
-        path=args.path, ignore=args.ignore, categorize=(not args.no_categorize)
+        path=args.path,
+        strict=args.strict,
+        ignore=args.ignore,
+        categorize=(not args.no_categorize),
     )
     if cycles := checker.cycles:
         retv = 1

--- a/ouro/nodes_initializer.py
+++ b/ouro/nodes_initializer.py
@@ -5,7 +5,6 @@ from typing import List
 from typing import Set
 from typing import Tuple
 from typing import Union
-
 from ouro.reader import Reader
 
 
@@ -20,13 +19,16 @@ class Node:
 
 
 class NodesInitializer:
-    def __init__(self, path: str, ignore: Union[List[str], None] = None) -> None:
+    def __init__(
+        self, path: str, walker: callable, ignore: Union[List[str], None] = None
+    ) -> None:
         self.nodes: Dict[Path, "Node"] = {}
 
         with Reader(path, ignore=ignore) as reader_obj:
             self._files = reader_obj.files
             self._prg_path = reader_obj.path
 
+        self._walker = walker
         self._initialize()
 
     def _get_node(self, file_path: Path) -> "Node":
@@ -40,7 +42,7 @@ class NodesInitializer:
     ) -> List[Union[ast.Import, ast.ImportFrom]]:
         return [
             node
-            for node in ast.walk(ast.parse(file_content))
+            for node in self._walker(ast.parse(file_content))
             if isinstance(node, (ast.Import, ast.ImportFrom))
         ]
 

--- a/tests/test_func_imports/file_a.py
+++ b/tests/test_func_imports/file_a.py
@@ -1,0 +1,10 @@
+from file_b import B
+
+
+def A(n):
+    B(n - 1)
+    print("A", n)
+
+
+if __name__ == "__main__":
+    A(2)

--- a/tests/test_func_imports/file_b.py
+++ b/tests/test_func_imports/file_b.py
@@ -1,0 +1,7 @@
+def B(n):
+    if n < 0:
+        return
+    from file_a import A
+
+    A(n - 1)
+    print("B", n)


### PR DESCRIPTION
Added the ability to toggle whether function definitions should be walked or not (maybe class definitions can also be skipped for speedup in the last case?). 

Default behavior is to not check for imports within functions, as these do not necessarily create errors. This behavior can be enabled with `-t` or `--strict` as flags.

It was not very clear to me how I should write proper tests and check that the changes do not break anything else (the repo was a bit messy there). Only for convenience, I created a directory `tests/test_func_imports` and added there my testing scenario: 

```bash
pip install -e .
cd tests
cd test_func_imports
ouro 
ouro -strict
```

P.S. For testing: `ouro tests/test_func_imports` wasn't working for me from the top level (I imagine it was considering this as a file?). Similarly, it would have been nice to get an error if a file does not exist.